### PR TITLE
使高级搜索筛选按钮显示

### DIFF
--- a/src/base.tid
+++ b/src/base.tid
@@ -340,17 +340,12 @@ a.tc-tiddlylink.tc-tiddlylink-resolves.tc-plugin-info.tc-popup-handle.tc-popup-a
 	侧边栏搜索框
 */
 
-.tc-search {
-	display: flex;
-	flex-direction: column;
-}
-
 .tc-search > input[type=search] {
 	flex: 1;
   border: 1px solid #999;
 }
-/** 隐藏没用的搜索栏按钮 */
-.tc-search > span > button:nth-child(1), .tc-search > span > button:nth-child(2) {
+/** 隐藏没用的侧边栏的搜索栏按钮 */
+.tc-sidebar-search > p > div > span > button {
 	display: none;
 }
 


### PR DESCRIPTION
```css
.tc-search > input[type=search] {
	flex: 1;
  border: 1px solid #999;
}
```
这段css删掉和不删掉好像没区别。但我没删掉这一段。


备忘录：https://zhuanlan.zhihu.com/p/375401959